### PR TITLE
add the application tag to the query by default

### DIFF
--- a/lib/capistrano/puppetdb.rb
+++ b/lib/capistrano/puppetdb.rb
@@ -17,7 +17,7 @@ module Capistrano
         ::PuppetDB::Query[:'=', 'type', query_resource_type],
         ::PuppetDB::Query[:'=', 'tag', application],
         ::PuppetDB::Query[:'=', 'tag', tag]
-      ]
+      ].reduce(&:and)
 
       server_map = client.request('resources', query).data.inject({}) do |hashmap, role_resource|
         hashmap[role_resource['certname']] ||= Set.new


### PR DESCRIPTION
This change will add the application name to the query to scope all server lists to only that environment.  This could occur if the resource type and the tag are the same across application, like when using the environment as the puppet filter tag
