### PR TITLE
Ensure symbols are sent to capistrano roles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,33 @@
 PATH
   remote: .
   specs:
-    capistrano-puppetdb (0.0.1)
+    capistrano-puppetdb (0.1.0)
       capistrano
       puppetdb-ruby
 
 GEM
   remote: https://rubygems.org/
   specs:
-    capistrano (3.2.1)
+    airbrussh (1.3.0)
+      sshkit (>= 1.6.1, != 1.7.0)
+    capistrano (3.11.0)
+      airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
-    colorize (0.7.3)
-    httparty (0.13.3)
-      json (~> 1.8)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.0.5)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    i18n (0.6.11)
-    json (1.8.1)
-    multi_xml (0.5.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    multi_xml (0.6.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
-    puppetdb-ruby (0.0.1)
+    net-ssh (5.0.2)
+    puppetdb-ruby (1.1.1)
       httparty
-    rake (10.3.2)
-    sshkit (1.5.1)
-      colorize
+    rake (12.3.1)
+    sshkit (1.16.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
 
@@ -35,3 +36,6 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano-puppetdb!
+
+BUNDLED WITH
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     capistrano-puppetdb (0.1.0)
       capistrano
-      puppetdb-ruby
+      puppetdb-ruby (= 0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
-    puppetdb-ruby (1.1.1)
+    puppetdb-ruby (0.0.1)
       httparty
     rake (12.3.1)
     sshkit (1.16.1)

--- a/capistrano-puppetdb.gemspec
+++ b/capistrano-puppetdb.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "capistrano"
-  s.add_runtime_dependency "puppetdb-ruby"
+  s.add_runtime_dependency("puppetdb-ruby", '0.0.1')
 end
 

--- a/capistrano-puppetdb.gemspec
+++ b/capistrano-puppetdb.gemspec
@@ -4,11 +4,11 @@ require "capistrano/puppetdb/version"
 Gem::Specification.new do |s|
   s.name        = 'capistrano-puppetdb'
   s.version     = Capistrano::PuppetDB::VERSION
-  s.date        = '2014-12-15'
+  s.date        = '2018-06-21'
   s.summary     = 'Use puppetdb to provide hosts for capistrano'
   s.description = 'queries puppetdb for host and role information'
-  s.authors     = ['Jeremy Kitchen']
-  s.email       = 'jeremy@nationbuilder.com'
+  s.authors     = ['Jeremy Kitchen', 'James Fryman']
+  s.email       = 'ops@nationbuilder.com'
   s.files       = ["lib/hola.rb"]
   s.homepage    = 'http://github.com/3dna/capistrano-puppetdb'
   s.license       = 'BSD'

--- a/lib/capistrano/puppetdb.rb
+++ b/lib/capistrano/puppetdb.rb
@@ -26,7 +26,8 @@ module Capistrano
         if !(role_list & fetch(:bundle_roles)).empty?
           no_release = false
         end
-        server certname, user: 'rails', roles: role_list.to_a, primary: true, no_release: no_release
+
+        server certname, user: 'rails', roles: role_list.to_a.map { |m| m.to_sym }, primary: true, no_release: no_release
       end
     end
   end

--- a/lib/capistrano/puppetdb/version.rb
+++ b/lib/capistrano/puppetdb/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module PuppetDB
-    VERSION = "0.0.1"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
This PR adjusts the output of `Set` from the collection via PuppetDB and ensures that an array of symbols is passed along to Capistrano in order to register multiple roles. 

/cc https://github.com/3dna/puppet/pull/366